### PR TITLE
Fix menu drop down on mobile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
       <img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="{{ headshot.url }}" loading="lazy" alt="Headshot">
     </span>
     </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
@@ -30,10 +30,6 @@
             <li class="nav-item">
                 <a class="nav-link" href="/recipes">Recipes</a>
             </li>
-
-<!--            <li class="nav-item">
-                <a class="nav-link" href="/resume.pdf">Resume</a>
-            </li> -->
             <li class="nav-item">
                 <a href="https://www.linkedin.com/in/stusmall/">
                 <span class="fa-stack fa-lg">


### PR DESCRIPTION
Bootstrap 5 made a breaking chaxnge to a couple attributes.  I missed catching this when updating.  This just corrects the attributes.  The layout stil looks a little off but I can fix that later